### PR TITLE
Remove requirement against < activesupport 6.0

### DIFF
--- a/autometal-piwik.gemspec
+++ b/autometal-piwik.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('xml-simple')
   s.add_dependency('rest-client')
-  s.add_dependency('activesupport', '>= 3.0', '< 6.0')
+  s.add_dependency('activesupport', '>= 3.0', '< 7.0')
   s.add_development_dependency('rspec', '< 3.0')
 end


### PR DESCRIPTION
This allows integration with Rails 6.