### PR TITLE
Deprecation warnings

### DIFF
--- a/autometal-piwik.gemspec
+++ b/autometal-piwik.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency('rest-client')
   s.add_dependency('activesupport', '>= 3.0', '< 7.0')
   s.add_development_dependency('rspec', '< 3.0')
+  s.add_development_dependency('rspec-its', '< 3.0')
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'rspec/its'
 require 'piwik'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Fix rspec deprecation warnings by adding rspec-its to development dependencies.