### PR TITLE
Update # FAQ Links

### DIFF
--- a/spec/files/Live.getLastVisitsDetails.xml
+++ b/spec/files/Live.getLastVisitsDetails.xml
@@ -356,7 +356,7 @@
 		<referrerName>Google</referrerName>
 		<referrerKeyword>Suchbegriff nicht definiert</referrerKeyword>
 		<referrerKeywordPosition>1</referrerKeywordPosition>
-		<referrerUrl>http://piwik.org/faq/general/#faq_144</referrerUrl>
+		<referrerUrl>http://matomo.org/faq/general/faq_144</referrerUrl>
 		<referrerSearchEngineUrl>http://google.com</referrerSearchEngineUrl>
 		<referrerSearchEngineIcon>plugins/Referers/images/searchEngines/google.com.png</referrerSearchEngineIcon>
 		<operatingSystem>Windows 7</operatingSystem>
@@ -450,13 +450,13 @@
 		<latitude />
 		<longitude />
 		<provider>IP</provider>
-		<providerUrl>http://piwik.org/faq/general/#faq_52</providerUrl>
+		<providerUrl>http://matomo.org/faq/general/faq_52</providerUrl>
 		<referrerType>search</referrerType>
 		<referrerTypeName>Suchmaschinen</referrerTypeName>
 		<referrerName>Google</referrerName>
 		<referrerKeyword>Suchbegriff nicht definiert</referrerKeyword>
 		<referrerKeywordPosition>6</referrerKeywordPosition>
-		<referrerUrl>http://piwik.org/faq/general/#faq_144</referrerUrl>
+		<referrerUrl>http://matomo.org/faq/general/faq_144</referrerUrl>
 		<referrerSearchEngineUrl>http://google.com</referrerSearchEngineUrl>
 		<referrerSearchEngineIcon>plugins/Referers/images/searchEngines/google.com.png</referrerSearchEngineIcon>
 		<operatingSystem>Windows 7</operatingSystem>
@@ -556,7 +556,7 @@
 		<referrerName>Google</referrerName>
 		<referrerKeyword>Suchbegriff nicht definiert</referrerKeyword>
 		<referrerKeywordPosition>1</referrerKeywordPosition>
-		<referrerUrl>http://piwik.org/faq/general/#faq_144</referrerUrl>
+		<referrerUrl>http://matomo.org/faq/general/faq_144</referrerUrl>
 		<referrerSearchEngineUrl>http://google.com</referrerSearchEngineUrl>
 		<referrerSearchEngineIcon>plugins/Referers/images/searchEngines/google.com.png</referrerSearchEngineIcon>
 		<operatingSystem>Mac OS</operatingSystem>

--- a/spec/files/Provider.getProvider.xml
+++ b/spec/files/Provider.getProvider.xml
@@ -9,7 +9,7 @@
 		<sum_visit_length>31414</sum_visit_length>
 		<bounce_count>150</bounce_count>
 		<nb_visits_converted>14</nb_visits_converted>
-		<url>http://piwik.org/faq/general/#faq_52</url>
+		<url>http://matomo.org/faq/general/faq_52</url>
 	</row>
 	<row>
 		<label>T-dialin</label>
@@ -75,7 +75,7 @@
 		<sum_visit_length>4895</sum_visit_length>
 		<bounce_count>5</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
-		<url>http://piwik.org/faq/general/#faq_52</url>
+		<url>http://matomo.org/faq/general/faq_52</url>
 	</row>
 	<row>
 		<label>Btcentralplus</label>


### PR DESCRIPTION
A recent knowledge base update has changed how FAQ links work on matomo.org

Links with `#` in the link no longer work for guides or FAQs